### PR TITLE
Update HOST_URL variable in Beanstalk environment

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 
 # Before you use...
 - Download and install [Terraform](https://www.terraform.io/downloads.html) on your system.
-- Configure aws-cli on your system.
+- Install & Configure [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-windows.html) on your system.
 - Setup a aws provider profile using `aws configure`
 - Create a s3 Bucket to store `tfstate` files remotely. We recommend enable versioning on that bucket.
 >   aws s3api create-bucket --acl private --bucket terraform-artifacts-bucket

--- a/terraform/aws-ebs-with-rds/iam.tf
+++ b/terraform/aws-ebs-with-rds/iam.tf
@@ -10,6 +10,7 @@ resource "aws_iam_instance_profile" "app-ec2-role" {
 
 resource "aws_iam_role" "app-ec2-role" {
   name               = "${var.environment}-${var.prefix}-app-ec2-role"
+  force_detach_policies = true
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -34,6 +35,7 @@ EOF
 # service
 resource "aws_iam_role" "elasticbeanstalk-service-role" {
   name               = "${var.environment}-${var.prefix}-elasticbeanstalk-service-role"
+  force_detach_policies = true
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/terraform/environments/dev/dev.tf
+++ b/terraform/environments/dev/dev.tf
@@ -78,6 +78,12 @@ module "aws-ebs-app" {
   PATH_TO_PUBLIC_KEY      = "~/.ssh/id_rsa.pub"
 }
 
+resource "null_resource" "update-ebs-env" { 
+  provisioner "local-exec" {
+    command = "aws elasticbeanstalk update-environment --environment-name ${module.aws-ebs-app.application} --option-settings Namespace=aws:elasticbeanstalk:application:environment,OptionName=HOST_URL,Value=${module.aws-ebs-app.ebs-cname}/api"
+  }
+}
+
 module "aws-code-pipeline"{
 
   source = "../../aws-codepipeline"


### PR DESCRIPTION
We are using `local-exec` provisioner provided by terraform that lets us execute commands. we are using `aws elasticbeanstalk update-environment` command. 

**NOTE** - it is presumed that aws-cli will be installed on the machine executing terraform script.